### PR TITLE
Update to use cmfcmf/openweathermap-php-api ^3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 `composer require coliving/laravel-owm`
 
+You will also need a PSR-17 compatible HTTP factory implementation and a PSR-18 compatible HTTP client implementation. Laravel already requires guzzle as a http client, but you may need to add a http-factory package. Choose any [from this list](https://packagist.org/providers/psr/http-factory-implementation) or use the suggested package below:
+
+```
+composer require "http-interop/http-factory-guzzle:^1.0"
+```
+
 #### 2. Add this line to your conf/app.php file
 
 For Laravel == 5.0.*

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,12 @@
     "keywords": ["weather","clima","open weather map","laravel"],
     "require": {
         "php": ">=7.2.0",
-        "cmfcmf/openweathermap-php-api": "^2.1"
+        "cmfcmf/openweathermap-php-api": "^3.0",
+        "php-http/discovery": "^1.13"
     },
-
+    "require-dev": {
+        "php-http/mock-client": "1.4.x-dev"
+    },
     "license": "MIT",
 
     "authors": [

--- a/src/LaravelOWM.php
+++ b/src/LaravelOWM.php
@@ -2,6 +2,10 @@
 namespace Gmopx\LaravelOWM;
 
 use Cmfcmf\OpenWeatherMap;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 
 class LaravelOWM
 {
@@ -14,6 +18,18 @@ class LaravelOWM
      * @var
      */
     protected $api_key;
+
+    /**
+     * Psr18 http client
+     * @var ClientInterface
+     */
+    protected $httpClient;
+
+    /**
+     * Psr17 http Factory
+     * @var RequestFactoryInterface
+     */
+    protected $httpRequestFactory;
 
     public function __construct()
     {
@@ -28,6 +44,9 @@ class LaravelOWM
         }
 
         $this->api_key = $this->config['api_key'];
+
+        $this->httpClient = Psr18ClientDiscovery::find();
+        $this->httpRequestFactory = Psr17FactoryDiscovery::findRequestFactory();
     }
 
     /**
@@ -55,11 +74,11 @@ class LaravelOWM
         $units = $units ?: 'metric';
 
         if ($cache) {
-            $owm = new OpenWeatherMap($this->api_key, null, new Cache(), $time);
+            $owm = new OpenWeatherMap($this->api_key, $this->httpClient, $this->httpRequestFactory, new Cache(), $time);
             return $owm->getWeather($query, $units, $lang);
         }
 
-        $owm = new OpenWeatherMap($this->api_key);
+        $owm = new OpenWeatherMap($this->api_key, $this->httpClient, $this->httpRequestFactory);
         return $owm->getWeather($query, $units, $lang);
     }
 


### PR DESCRIPTION
This updates moves to support version 3 of openweathermap-php-api. It adds in the new version constraint, as well as Http client and request factory discovery logic to provide the clients now required by the library. There is also additional text added to the readme to highlight the new installation requirements. 

This upgrade works well for me (and I've been using a similarly edited fork for a while!) but version 3.x of the php-api [has several breaking changes](https://github.com/cmfcmf/OpenWeatherMap-PHP-API/releases/tag/v3.0.0) which will likely break some users existing code. This upgrade should therefore be semantically versioned to highlight the deprecated methods and the change to the unit labels etc.

I wonder if it would make sense to move this whole library also to version 3.x to stay in sync with the major version of openweathermap-php-api as breaking changes there will always break things for users here - and it makes that dependency clearer.  I'm not sure if that might get confusing if we also need to break things for a new laravel release or other reason though.